### PR TITLE
Update `upload-artifact` versions.

### DIFF
--- a/.github/workflows/pr-close-signal.yaml
+++ b/.github/workflows/pr-close-signal.yaml
@@ -16,7 +16,7 @@ jobs:
           mkdir -p ./pr
           printf ${{ github.event.number }} > ./pr/NUM
       - name: Upload Diff
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pr
           path: ./pr

--- a/.github/workflows/pr-receive.yaml
+++ b/.github/workflows/pr-receive.yaml
@@ -113,14 +113,14 @@ jobs:
           path: ${{ env.PR }}
 
       - name: "Upload Diff"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: diff
           path: ${{ env.CHIVE }}
           retention-days: 1
 
       - name: "Upload Build"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: built
           path: ${{ env.MD }}


### PR DESCRIPTION
[Version 3 is deprecated](https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/#artifacts-v3-brownouts).